### PR TITLE
feat: #53 limit and rank the collage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 ./run.sh                                    # Pi only: converge an existing checkout (BirdNET-Go + services)
 ```
 
-**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
+**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, how many species and which ones, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
 
 ## Architecture
 
@@ -38,7 +38,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 
 **Render once, fan out** (`service.py`).
 
-- The loop re-renders only when its inputs change: species in the window, panel size, style, rotation, names + language + typeface.
+- The loop re-renders only when its inputs change: the species on the page, panel size, style, rotation, names + language + typeface.
 - It dithers to 6 colors and pushes to the panel; the kiosk serves the same page full-color at its own pixel count. No panel means web-only, the same path as `--preview`.
 
 **The panel sizes itself** (`panel.py`).
@@ -72,6 +72,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 - The packer works in whole pixels (`_STEP`, `_OVERLAP_PX`), so it is not scale-invariant: it packs at `_PACK_SHORT` and scales the placements to the output. Packing at the output size instead swapped birds between the panel and the kiosk. Sprites and labels are redrawn from source at the target size, never resampled from the packed raster, and a label is centred in the box `_with_label` reserved for it since a re-rasterized font is not exactly `width × scale`.
 - Packing is ~90% of a render and both outputs pack identically, so `_placements` caches it (`_layouts`, keyed on the species and their artwork, the pack size, and the resolved label strings). The loop's panel render pays for the kiosk's: 5.4s to 0.5s here. The lock is held across the pack so the second caller waits rather than packing its own copy.
 - No-artwork species are omitted. An empty window draws one branch from the style's own `perches/`, chosen by day (`collage.perch_day`, in both cache keys).
+- `selected_species` is the single answer to which birds are on the page: it drops what the style cannot draw, then applies the admin's limit under the admin's ranking, then `MAX_BIRDS` as the frame's own render budget - spent on the most heard, since the ranking only applies under a limit. The key reads *that* list, not the window's - under a limit two birds can trade places across it while the set of species heard sits still.
 - A label's box joins its bird's collision mask, so it tucks under the body and never lands on a neighbour. A second language stacks below in parentheses.
 - On the panel labels are hard-thresholded to pure black: antialiased grey dithers into colour speckle.
 

--- a/docs/display.md
+++ b/docs/display.md
@@ -36,6 +36,27 @@ How far back the collage looks, from the last 6 hours to all time. Default is
 
 **All time** never drops a species, so the page only grows.
 
+### Species on the page
+
+How many species the collage shows, and which ones it keeps when the window
+holds more than that. Default is **No limit**. Only the collage uses it.
+
+A busy garden can hear thirty species in a day, and thirty birds on one sheet
+are thirty *small* birds. Set a limit and pick which end to keep:
+
+| Which ones to keep | Good for |
+| --- | --- |
+| The most heard | The birds that really live around you |
+| The rarest | The one-off visitors, where the surprises are |
+
+**The rarest** is worth a try if your list is the same residents every day. A
+hoopoe that passed through once is easy to miss among thirty birds and hard to
+miss among eight.
+
+The frame draws at most 40 species whatever you pick, so **No limit** means
+"everything the window heard, up to 40" - the 40 most heard, if it comes to
+that.
+
 ### Species names
 
 **Show species names** turns the labels on and off, same as **B** on the panel.

--- a/src/fugleramme/modes.py
+++ b/src/fugleramme/modes.py
@@ -27,7 +27,7 @@ from PIL import Image
 from .languages import Namer
 from .names import drawable_keys, image_for, normalize, perches_for, resolve
 from .picks import Picks
-from .render.collage import gather_entries, render_collage
+from .render.collage import gather_entries, render_collage, selected_species
 from .render.page import day_ordinal
 from .render.plate import render_plate
 from .source import Source, Species
@@ -56,6 +56,8 @@ class Context:
     lookback_hours: int
     font_key: str
     label_size: str
+    species_limit: int
+    ranking: str
     textured: bool = True
 
     def perches(self):
@@ -88,6 +90,8 @@ def context(
         lookback_hours=settings.lookback_hours,
         font_key=settings.label_font,
         label_size=settings.label_size,
+        species_limit=settings.species_limit,
+        ranking=settings.ranking,
         textured=textured,
     )
 
@@ -120,15 +124,38 @@ def _plate(ctx: Context, name: str | None, note: str = "", art: Path | None = No
     )
 
 
+def _selected(ctx: Context) -> list[str]:
+    """The species on the collage, in name order. Asked on every poll by the key
+    and the render alike, and cheap enough for it."""
+    return selected_species(
+        ctx.source,
+        ctx.images_dir,
+        ctx.style,
+        ctx.lookback_hours,
+        ctx.species_limit,
+        ctx.ranking,
+    )
+
+
 def _collage_key(ctx: Context) -> tuple:
-    # Sorted to keep key constant for the same bird set (avoid re-renders on order change)
-    species = tuple(sorted(name for name, _ in ctx.source.species_since(ctx.lookback_hours)))
+    # The species actually on the page, in name order (no re-render when the
+    # ranking reorders them). Not the window's: under a limit two birds trading
+    # places across it change the picture while the window's own set sits still.
+    species = tuple(_selected(ctx))
     return (species, day_ordinal() if not species else None)
 
 
 def _collage(ctx: Context) -> Image.Image:
     return render_collage(
-        gather_entries(ctx.source, ctx.images_dir, ctx.style, ctx.picks, ctx.lookback_hours),
+        gather_entries(
+            ctx.source,
+            ctx.images_dir,
+            ctx.style,
+            ctx.picks,
+            ctx.lookback_hours,
+            ctx.species_limit,
+            ctx.ranking,
+        ),
         ctx.resolution,
         ctx.show_names,
         ctx.textured,
@@ -202,14 +229,26 @@ def _one(species) -> list[str]:
 
 
 def _collage_subjects(ctx: Context) -> list[str]:
-    # The whole window, art-less species included: the admin marks those as
-    # counted but not drawn.
-    return [name for name, _ in ctx.source.species_since(ctx.lookback_hours)]
+    """What is on the page, plus every species the window counted that this style
+    cannot draw - the admin marks those as counted but not drawn (#9), which is
+    how a missing plate gets reported. Species the limit left out are not listed:
+    that is not a gap in the frame, it is the admin asking for a shorter page.
+    """
+    keys = ctx.drawable()
+    counted = ctx.source.species_since(ctx.lookback_hours)
+    artless = [name for name, _ in counted if normalize(name) not in keys]
+    return sorted(_selected(ctx) + artless)
 
 
 # Insertion order is the order button A walks.
 MODES: dict[str, Mode] = {
-    "collage": Mode("Collage (default)", _collage, _collage_key, _collage_subjects, windowed=True),
+    "collage": Mode(
+        "Collage (default)",
+        _collage,
+        _collage_key,
+        _collage_subjects,
+        windowed=True,
+    ),
     "latest": Mode(
         "Latest bird",
         _latest_page,

--- a/src/fugleramme/render/collage.py
+++ b/src/fugleramme/render/collage.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import numpy as np
 from PIL import Image, ImageFilter
 
-from ..names import image_for
+from ..names import drawable_keys, image_for, normalize
 from ..picks import Picks
 from ..source import Source
 from . import fonts
@@ -56,7 +56,21 @@ DEFAULT_RESOLUTION = (1280, 800)
 # panel and the kiosk on different pages.
 _PACK_SHORT = 1200
 _MARGIN = 0.04  # page edge to content on short side. Hardcoded now, maybe add configurability?
-_MAX_BIRDS = 40  # keeps the render quick, not the page tidy
+# The frame's own ceiling whatever the admin asks for: a render is ~90% packing
+# and the Pi has to finish it. Keeps the render quick, not the page tidy.
+MAX_BIRDS = 40
+
+# How many species the admin lets on, and which ones (#53). NO_LIMIT still means
+# "every bird the window holds", not "however long the Pi takes to draw them".
+NO_LIMIT = 0
+LIMIT_OPTIONS = (NO_LIMIT, 5, 8, 10, 12, 15, 20, 30)
+RANK_MOST_HEARD = "heard"
+RANK_RAREST = "rarest"
+RANKINGS = {
+    RANK_MOST_HEARD: "The most heard",
+    RANK_RAREST: "The rarest",  # at a busy station the visitor is the interesting one
+}
+DEFAULT_RANKING = RANK_MOST_HEARD
 _ALPHA_CUTOFF = 24
 _OVERLAP_PX = 2  # erode the collision mask slightly so birds nestle into
 # each other's (invisible on paper) halos. No rotation:
@@ -354,7 +368,7 @@ def render_collage(
     """
     canvas = blank(resolution, textured)
 
-    kept = [(name, path) for name, path in entries if path is not None][:_MAX_BIRDS]
+    kept = [(name, path) for name, path in entries if path is not None][:MAX_BIRDS]
     if not kept:
         draw_perch(canvas, perches, day_ordinal(), textured)
         return canvas
@@ -413,19 +427,57 @@ def _at(at: tuple[int, int], scale: float) -> tuple[int, int]:
     return round(at[0] * scale), round(at[1] * scale)
 
 
+def _rank(ranking: str):
+    """Sort key that puts the birds the admin asked to keep first. Ties break on
+    the name, so a page at its limit does not flicker between two equal birds."""
+    if ranking == RANK_RAREST:
+        return lambda pair: (pair[1], pair[0])
+    return lambda pair: (-pair[1], pair[0])
+
+
+def selected_species(
+    source: Source,
+    images_dir: Path,
+    style: str,
+    hours: int = 24,
+    limit: int = NO_LIMIT,
+    ranking: str = DEFAULT_RANKING,
+) -> list[str]:
+    """The species that make the page, in name order.
+
+    Name order because the order birds are handed over must not depend on their
+    counts - a bird merely heard again would reshuffle the whole packing. Which
+    birds are on it does depend on the counts once a limit is set, so the page's
+    key is built from this same list.
+
+    The ranking only applies under a limit, as the admin says: with none set the
+    frame's own ceiling keeps the most heard, whatever the greyed-out field holds.
+
+    What the style cannot draw is dropped before the limit, so a plate the frame
+    does not have never takes one of the places. One directory listing, not a
+    probe per species: the loop asks for this on every poll, and so does the
+    kiosk.
+    """
+    keys = drawable_keys(images_dir, style)
+    counted = [(name, n) for name, n in source.species_since(hours) if normalize(name) in keys]
+    if limit == NO_LIMIT:
+        limit, ranking = MAX_BIRDS, DEFAULT_RANKING
+    ranked = sorted(counted, key=_rank(ranking))
+    return sorted(name for name, _n in ranked[: min(limit, MAX_BIRDS)])
+
+
 def gather_entries(
     source: Source,
     images_dir: Path,
     style: str,
     picks: Picks,
     hours: int = 24,
+    limit: int = NO_LIMIT,
+    ranking: str = DEFAULT_RANKING,
 ) -> list[tuple[str, Path | None]]:
-    """Recent-window species paired with the artwork each is wearing, or None.
-
-    In name order, matching the collage's cache key: the page is a function of
-    the species set alone, so a count moving must not reshuffle the layout.
-    """
+    """The page's species paired with the artwork each is wearing. The None only
+    stands for a file that vanished between `selected_species` and here."""
     return [
         (name, image_for(name, images_dir, style, picks))
-        for name, _count in sorted(source.species_since(hours))
+        for name in selected_species(source, images_dir, style, hours, limit, ranking)
     ]

--- a/src/fugleramme/settings.py
+++ b/src/fugleramme/settings.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from .config import DEFAULT_DETECTOR_URL, DEFAULT_WEB_RESOLUTION, WEB_HEIGHTS
 from .languages import NONE, SCIENTIFIC
 from .modes import DEFAULT_MODE, MODES
+from .render.collage import DEFAULT_RANKING, MAX_BIRDS, NO_LIMIT, RANKINGS
 from .render.fonts import DEFAULT_FONT, DEFAULT_LABEL_SIZE, FONTS, LABEL_SIZES
 
 # How the frame hangs, counter-clockwise. 0/180 render landscape, 90/270 portrait.
@@ -54,6 +55,9 @@ class Settings:
     # Shapes both outputs; only the panel actually turns the pixels.
     rotation: int = 0
     lookback_hours: int = 24
+    # Which birds make the page (#53); no limit leaves an existing frame alone.
+    species_limit: int = NO_LIMIT
+    ranking: str = DEFAULT_RANKING
     # Active artwork style folder; empty means "whichever is present" (resolved
     # against the filesystem at render time, so it survives a renamed style).
     style: str = ""
@@ -159,6 +163,8 @@ def _coerce(raw: dict, base: Settings | None = None) -> Settings:
         ),
         rotation=_one_of(rotation, ROTATIONS, d.rotation),
         lookback_hours=_as_int(raw.get("lookback_hours"), d.lookback_hours, ALL_TIME, 24 * 30),
+        species_limit=_as_int(raw.get("species_limit"), d.species_limit, NO_LIMIT, MAX_BIRDS),
+        ranking=_one_of(str(raw.get("ranking", d.ranking)), RANKINGS, d.ranking),
         style=_style(raw, d.style),
         auto_update=_as_bool(raw.get("auto_update"), d.auto_update),
         show_names=_as_bool(raw.get("show_names"), d.show_names),

--- a/src/fugleramme/web/admin.py
+++ b/src/fugleramme/web/admin.py
@@ -20,6 +20,7 @@ from ..config import BIRDNET_PORT, DOCS_URL, WEB_HEIGHTS
 from ..languages import NONE, Namer, catalog, catalog_failure, ordered
 from ..modes import MODES
 from ..names import available_styles, image_for, origin_of, source_of
+from ..render.collage import LIMIT_OPTIONS, MAX_BIRDS, NO_LIMIT, RANKINGS
 from ..render.fonts import FONTS, LABEL_SIZES
 from ..settings import LOOKBACK_OPTIONS, ROTATIONS, Settings, lookback_order, merged
 from ..source import NEEDS_PASSWORD, Unavailable
@@ -303,6 +304,31 @@ def _lookbacks(settings: Settings) -> str:
     return _options(sorted(labels, key=lookback_order), settings.lookback_hours, labels.get)
 
 
+def _limits(settings: Settings) -> str:
+    # A hand-edited non-preset value stays selectable so Save doesn't drop it.
+    labels = {n: ("No limit" if n == NO_LIMIT else f"{n} species") for n in LIMIT_OPTIONS}
+    labels.setdefault(settings.species_limit, f"{settings.species_limit} species")
+    return _options(sorted(labels), settings.species_limit, labels.get)
+
+
+def _species_field(settings: Settings) -> str:
+    """How many species the collage shows, and which ones it keeps (#53).
+
+    "No limit" still names MAX_BIRDS, because that is the honest answer: it is
+    the render budget and no setting spends past it. admin.js greys the ranking
+    out until there is a limit, with nothing to choose between before that.
+    """
+    return (
+        f'<div class="field" id="limit">'
+        f"<span>Species on the page <small>(at most {MAX_BIRDS})</small></span>"
+        f'<label class="sub"><small>How many</small><select name="species_limit">'
+        f"{_limits(settings)}</select></label>"
+        f'<label class="sub" id="ranking"><small>Which ones to keep</small>'
+        f'<select name="ranking">{_options(RANKINGS, settings.ranking, RANKINGS.get)}</select>'
+        f"</label></div>"
+    )
+
+
 def page(
     ctx: modes.Context,
     settings: Settings,
@@ -342,6 +368,7 @@ def page(
                 "birdnetPort": birdnet_port,
                 "version": __version__,
                 "windowedModes": [k for k, m in MODES.items() if m.windowed],
+                "noLimit": str(NO_LIMIT),
             }
         ),
         mode_field=(
@@ -359,6 +386,7 @@ def page(
         lookback_off="" if windowed else ' class="off"',
         lookback_disabled="" if windowed else " disabled",
         lookbacks=_lookbacks(settings),
+        limit_field=_species_field(settings),
         names_field=_names_field(settings, languages, names_failure),
         style_field=(
             f'<div class="field"><span>Artwork style</span>'

--- a/src/fugleramme/web/static/admin.css
+++ b/src/fugleramme/web/static/admin.css
@@ -28,7 +28,7 @@ label.src input { width: auto; padding: 0; }
 button { font-size: 1rem; padding: 0.5rem 1.25rem; margin-top: 0.5rem; }
 button:disabled { opacity: 0.45; }
 /* A setting the chosen mode does not read: shown, so its value is not a surprise on the way back. */
-label.off { opacity: 0.45; }
+label.off, .field.off { opacity: 0.45; }
 a { color: #446; }
 dl.status { display: grid; grid-template-columns: auto 1fr; gap: 0.35rem 1rem;
             background: #f4f2ee; padding: 1rem 1.25rem; border-radius: 6px; margin: 0 0 1.75rem; }

--- a/src/fugleramme/web/static/admin.html
+++ b/src/fugleramme/web/static/admin.html
@@ -26,6 +26,7 @@
     <label id="lookback"$lookback_off>
       <span>Lookback window <small>(how far back the frame looks)</small></span>
       <select name="lookback_hours"$lookback_disabled>$lookbacks</select></label>
+    $limit_field
     $names_field
     $style_field
     <button type="submit">Save</button>

--- a/src/fugleramme/web/static/admin.js
+++ b/src/fugleramme/web/static/admin.js
@@ -163,11 +163,20 @@ async function loadSpecies(query, id) {
 // Settings the chosen mode ignores go dim and stop being submitted, so the
 // saved value survives a trip through a mode that has no use for it.
 const lookback = document.getElementById("lookback");
+const limit = document.getElementById("limit");
+const ranking = document.getElementById("ranking");
+function dim(el, on) {
+  el.querySelectorAll("select").forEach((s) => { s.disabled = !on; });
+  el.classList.toggle("off", !on);
+}
 function syncMode() {
   const mode = form.querySelector("input[name=mode]:checked");
   const on = !mode || cfg.windowedModes.includes(mode.value);
-  lookback.querySelector("select").disabled = !on;
-  lookback.classList.toggle("off", !on);
+  dim(lookback, on);
+  dim(limit, on);
+  // Nothing to rank while every bird the window heard is already on the page.
+  const capped = form.querySelector("select[name=species_limit]").value !== cfg.noLimit;
+  dim(ranking, on && capped);
 }
 
 // Capture, so a mode change settles which fields still submit before the shared

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -13,11 +13,13 @@ from PIL import Image
 from fugleramme import fake, modes
 from fugleramme.api import ApiSource
 from fugleramme.languages import namer
+from fugleramme.names import normalize
 from fugleramme.picks import Picks
 from fugleramme.settings import Settings
 
 NOW = datetime.now().astimezone()
 BLACKBIRD, TIT = "Turdus merula", "Parus major"
+ROBIN = "Erithacus rubecula"
 
 
 def _row(id_: int, name: str, ago_hours: float) -> fake.Detection:
@@ -41,6 +43,13 @@ def images(tmp_path):
     (style / "perches").mkdir()
     Image.new("RGBA", (80, 60), (20, 20, 20, 255)).save(style / "perches" / "twig.png")
     return tmp_path
+
+
+def _draw(images, name: str) -> None:
+    """Give a species a plate, so it can hold a place on the page."""
+    Image.new("RGBA", (120, 90), (40, 40, 40, 255)).save(
+        images / "classic" / "birds" / f"{normalize(name)}.png"
+    )
 
 
 def _ctx(source, images, tmp_path, mode, **overrides):
@@ -117,6 +126,54 @@ def test_the_collage_holds_the_page_when_a_bird_already_on_it_calls_again(
 
     assert detections.species_since()[0][0] == BLACKBIRD  # the ranking did flip
     assert modes.state_key(_ctx(detections, images, tmp_path, "collage")) == before
+
+
+def test_a_limit_keeps_the_most_heard_and_the_ranking_takes_the_other_end(tmp_path, images, source):
+    detections = source(rows=[_row(3, TIT, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)])
+    for ranking, expected in (("heard", BLACKBIRD), ("rarest", TIT)):
+        ctx = _ctx(detections, images, tmp_path, "collage", species_limit=1, ranking=ranking)
+        assert modes._selected(ctx) == [expected]
+
+
+def test_a_bird_crossing_the_limit_repaints_although_the_window_never_moved(
+    tmp_path, images, detector
+):
+    """The reason the key reads the page rather than the window. Under a limit
+    two birds can trade places across it while the set of species heard sits
+    perfectly still - and the picture changes."""
+    rows = [_row(3, TIT, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)]
+    url, _httpd = detector(rows=rows)
+    detections = ApiSource(url)
+
+    def ctx():
+        return _ctx(detections, images, tmp_path, "collage", species_limit=1)
+
+    window = {name for name, _ in detections.species_since()}
+    before = modes.state_key(ctx())
+    assert modes._selected(ctx()) == [BLACKBIRD]
+
+    for id_ in range(4, 9):
+        _heard(detections, rows, _row(id_, TIT, 0))
+
+    assert {name for name, _ in detections.species_since()} == window  # same birds heard
+    assert modes._selected(ctx()) == [TIT]  # different bird on the page
+    assert modes.state_key(ctx()) != before  # so the panel is told about it
+
+
+def test_the_admin_lists_a_bird_with_no_plate_but_not_one_the_limit_left_out(
+    tmp_path, images, source
+):
+    (images / "classic" / "birds" / "parus-major.png").unlink()  # counted, cannot be drawn
+    _draw(images, ROBIN)
+    rows = [_row(4, TIT, 1), _row(3, ROBIN, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)]
+    detections = source(rows=rows)
+
+    every = modes.subjects(_ctx(detections, images, tmp_path, "collage"))
+    assert every == sorted([BLACKBIRD, ROBIN, TIT])
+
+    # One place, and the blackbird is the most heard, so the robin loses it.
+    limited = modes.subjects(_ctx(detections, images, tmp_path, "collage", species_limit=1))
+    assert limited == sorted([BLACKBIRD, TIT])  # the tit for having no plate, not for losing
 
 
 def test_the_newest_arrival_is_the_latest_first_ever(tmp_path, images, source):

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,104 @@
+"""Which birds make the page (#53).
+
+A busy station hears more species than one sheet can hold. The admin's limit and
+ranking decide which ones it keeps, and the frame's own ceiling - MAX_BIRDS, a
+render budget - spends itself on the most heard rather than the first by name.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from fugleramme.names import normalize
+from fugleramme.picks import Picks
+from fugleramme.render import collage
+from fugleramme.render.collage import RANK_RAREST
+
+
+class _Counted:
+    """Just enough of a Source for gather_entries: who was heard, how often."""
+
+    def __init__(self, counts: dict[str, int]):
+        self._counts = counts
+
+    def species_since(self, hours: int = 24) -> list[tuple[str, int]]:
+        return sorted(self._counts.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def _garden(tmp_path, count: int, drawn: int | None = None) -> list[str]:
+    """`count` species, the i-th heard i+1 times, so the busiest sort last by
+    name. Only the first `drawn` of them get a plate."""
+    birds = tmp_path / "classic" / "birds"
+    birds.mkdir(parents=True, exist_ok=True)
+    names = [f"Testus sp{i:02d}" for i in range(count)]
+    for name in names[: count if drawn is None else drawn]:
+        Image.new("RGBA", (20, 16), (30, 30, 30, 255)).save(birds / f"{normalize(name)}.png")
+    return names
+
+
+def _on_page(tmp_path, names: list[str], **kwargs) -> list[str]:
+    source = _Counted({name: i + 1 for i, name in enumerate(names)})
+    return collage.selected_species(source, tmp_path, "classic", **kwargs)
+
+
+def test_the_frames_own_ceiling_keeps_the_most_heard_not_the_first_by_name(tmp_path):
+    """MAX_BIRDS is a render budget, so which birds it spends on is a real
+    choice. Cutting by name instead retired the busiest bird in the garden for
+    being called Turdus rather than Anas."""
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    kept = _on_page(tmp_path, names)
+
+    assert set(kept) == set(names[-collage.MAX_BIRDS :])  # the busiest, not the first
+    assert kept == sorted(kept)  # and still handed over in name order
+
+
+def test_a_limit_keeps_the_most_heard_by_default(tmp_path):
+    names = _garden(tmp_path, 20)
+    assert _on_page(tmp_path, names, limit=5) == sorted(names[-5:])
+
+
+def test_the_rarest_ranking_keeps_the_other_end(tmp_path):
+    """What the request was for: the residents are the same every day, so the
+    visitor worth seeing is the one at the bottom of the list."""
+    names = _garden(tmp_path, 20)
+    assert _on_page(tmp_path, names, limit=5, ranking=RANK_RAREST) == sorted(names[:5])
+
+
+def test_no_limit_is_the_default_and_still_answers_to_the_frames_ceiling(tmp_path):
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    assert len(_on_page(tmp_path, names)) == collage.MAX_BIRDS
+    assert len(_on_page(tmp_path, names, limit=collage.NO_LIMIT)) == collage.MAX_BIRDS
+    assert len(_on_page(tmp_path, names, limit=10)) == 10
+
+
+def test_the_ranking_has_no_say_until_there_is_a_limit(tmp_path):
+    """The admin greys the ranking out under "No limit", so a saved "rarest"
+    must not quietly decide which forty a busy station gets."""
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    by_default = _on_page(tmp_path, names)
+    assert _on_page(tmp_path, names, ranking=RANK_RAREST) == by_default
+    assert set(by_default) == set(names[-collage.MAX_BIRDS :])
+
+
+def test_a_species_with_no_artwork_never_takes_a_place_from_one_that_has_it(tmp_path):
+    # The loudest bird in the garden, and the style cannot draw it. Dropping it
+    # after the limit rather than before would spend a place on nothing.
+    names = _garden(tmp_path, 12, drawn=11)
+    loudest = names[-1]
+
+    kept = _on_page(tmp_path, names, limit=5)
+
+    assert loudest not in kept
+    assert kept == sorted(names[6:11])  # the five busiest it can actually draw
+
+
+def test_the_entries_carry_the_artwork_each_selected_bird_is_wearing(tmp_path):
+    names = _garden(tmp_path, 6)
+    source = _Counted({name: i + 1 for i, name in enumerate(names)})
+
+    entries = collage.gather_entries(
+        source, tmp_path, "classic", Picks(tmp_path / "artwork.json"), limit=3
+    )
+
+    assert [name for name, _path in entries] == sorted(names[-3:])
+    assert all(path is not None for _name, path in entries)


### PR DESCRIPTION
## What this changes

The two settings from #53, both defaulting to what the frame does today:

- **Species on the page**: how many species the collage shows. No limit by default.
- **Which ones to keep**: the most heard or the rarest, within the lookback window. Only kicks in once a limit is set, and the admin greys it out until then.

Species the style can't draw are dropped before the limit, so a missing plate never takes a place from a bird that has one. With no limit the frame's own ceiling of 40 now keeps the most heard rather than cutting alphabetically.

The collage's key reads the list of birds on the page rather than the window's species set. Under a limit two birds can trade places across it while the set of species heard stays the same, and the picture changes, so the panel has to be told.

The admin's species list still shows the birds the window counted that have no art, since that's how a missing plate gets reported, but not the ones the limit left out.

This is the first of the two PRs from the comment on #53. The second, size by how often heard, is stacked on top of this one.

## Checks

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest -q`
- [x] `uv.lock` committed, if `pyproject.toml` changed