### PR TITLE
feat: size birds by how often heard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 ./run.sh                                    # Pi only: converge an existing checkout (BirdNET-Go + services)
 ```
 
-**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
+**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, how many species and which ones, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
 
 ## Architecture
 
@@ -38,7 +38,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 
 **Render once, fan out** (`service.py`).
 
-- The loop re-renders only when its inputs change: species in the window, panel size, style, rotation, names + language + typeface.
+- The loop re-renders only when its inputs change: the species on the page, panel size, style, rotation, names + language + typeface.
 - It dithers to 6 colors and pushes to the panel; the kiosk serves the same page full-color at its own pixel count. No panel means web-only, the same path as `--preview`.
 
 **The panel sizes itself** (`panel.py`).
@@ -72,6 +72,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 - The packer works in whole pixels (`_STEP`, `_OVERLAP_PX`), so it is not scale-invariant: it packs at `_PACK_SHORT` and scales the placements to the output. Packing at the output size instead swapped birds between the panel and the kiosk. Sprites and labels are redrawn from source at the target size, never resampled from the packed raster, and a label is centred in the box `_with_label` reserved for it since a re-rasterized font is not exactly `width × scale`.
 - Packing is ~90% of a render and both outputs pack identically, so `_placements` caches it (`_layouts`, keyed on the species and their artwork, the pack size, and the resolved label strings). The loop's panel render pays for the kiosk's: 5.4s to 0.5s here. The lock is held across the pack so the second caller waits rather than packing its own copy.
 - No-artwork species are omitted. An empty window draws one branch from the style's own `perches/`, chosen by day (`collage.perch_day`, in both cache keys).
+- `selected_species` is the single answer to which birds are on the page: it drops what the style cannot draw, then applies the admin's limit under the admin's ranking, then `MAX_BIRDS` as the frame's own render budget - spent on the most heard, since the ranking only applies under a limit. The key reads *that* list, not the window's - under a limit two birds can trade places across it while the set of species heard sits still.
 - A label's box joins its bird's collision mask, so it tucks under the body and never lands on a neighbour. A second language stacks below in parentheses.
 - On the panel labels are hard-thresholded to pure black: antialiased grey dithers into colour speckle.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 ./run.sh                                    # Pi only: converge an existing checkout (BirdNET-Go + services)
 ```
 
-**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, how many species and which ones, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
+**Settings are runtime, flags are launch-only.** Display mode, kiosk resolution, rotation, lookback, how many species and which ones, what sizes them, the panel's breath, style, names (on/off, primary + optional second language, typeface, size) and auto-update all live in the admin UI (`:8080/admin`), persisted to `--config` (default `detector/data/settings.json`). The detector's address and password are settings too, so a frame can be re-pointed without a restart. The flags are `--detector`, `--images`, `--config`, `--output`, `--host`, `--port`, `--preview`; `--detector` only supplies the default for a settings file that carries no `detector_url` of its own. The panel's own size is never a setting.
 
 ## Architecture
 
@@ -39,6 +39,8 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 **Render once, fan out** (`service.py`).
 
 - The loop re-renders only when its inputs change: the species on the page, panel size, style, rotation, names + language + typeface.
+- A key has two halves (`modes.state_key` / `modes.steady_key`). The steady half must reach the glass at once; the emphasis half - how loud each bird has been - may be held back for `settings.breath_minutes`, and by default is held until the steady half moves anyway. The rule for the panel: a refresh you notice should mean the frame actually heard a new bird.
+- The breath is the panel's alone: `run` passes 0 with no panel, so a web-only frame is as live as it was before the setting existed. On a panelled frame the kiosk can read a size change up to one breath before the glass does - the only place the two outputs are allowed to differ, and only ever in how large a bird is, never in which birds are on the page.
 - It dithers to 6 colors and pushes to the panel; the kiosk serves the same page full-color at its own pixel count. No panel means web-only, the same path as `--preview`.
 
 **The panel sizes itself** (`panel.py`).
@@ -73,6 +75,8 @@ uv run python scripts/curate.py             # workstation only: contact sheet on
 - Packing is ~90% of a render and both outputs pack identically, so `_placements` caches it (`_layouts`, keyed on the species and their artwork, the pack size, and the resolved label strings). The loop's panel render pays for the kiosk's: 5.4s to 0.5s here. The lock is held across the pack so the second caller waits rather than packing its own copy.
 - No-artwork species are omitted. An empty window draws one branch from the style's own `perches/`, chosen by day (`collage.perch_day`, in both cache keys).
 - `selected_species` is the single answer to which birds are on the page: it drops what the style cannot draw, then applies the admin's limit under the admin's ranking, then `MAX_BIRDS` as the frame's own render budget - spent on the most heard, since the ranking only applies under a limit. The key reads *that* list, not the window's - under a limit two birds can trade places across it while the set of species heard sits still.
+- Size and centrality are one number, never two: a bird's weight decides how big it is drawn, and the sort by weight decides how early it goes down on the centre-out spiral. Body mass is one input to it (`sizes.SIZE_EXPONENT`) and, when the admin asks, how often the bird was heard is the other (`sizes.TIER_STEP`). The two are tuned to about the same strength so neither flattens the other, and both are divided by the present set's geometric mean so the cluster still fills the page.
+- Counts reach the layout as broad bands, never as counts (`sizes.count_tiers`). The layout is a function of its cache key and the loop repaints when that key moves, so a raw count in it would repack the page on every single detection.
 - A label's box joins its bird's collision mask, so it tucks under the body and never lands on a neighbour. A second language stacks below in parentheses.
 - On the panel labels are hard-thresholded to pure black: antialiased grey dithers into colour speckle.
 

--- a/docs/display.md
+++ b/docs/display.md
@@ -36,6 +36,27 @@ How far back the collage looks, from the last 6 hours to all time. Default is
 
 **All time** never drops a species, so the page only grows.
 
+### Species on the page
+
+How many species the collage shows, and which ones it keeps when the window
+holds more than that. Default is **No limit**. Only the collage uses it.
+
+A busy garden can hear thirty species in a day, and thirty birds on one sheet
+are thirty *small* birds. Set a limit and pick which end to keep:
+
+| Which ones to keep | Good for |
+| --- | --- |
+| The most heard | The birds that really live around you |
+| The rarest | The one-off visitors, where the surprises are |
+
+**The rarest** is worth a try if your list is the same residents every day. A
+hoopoe that passed through once is easy to miss among thirty birds and hard to
+miss among eight.
+
+The frame draws at most 40 species whatever you pick, so **No limit** means
+"everything the window heard, up to 40" - the 40 most heard, if it comes to
+that.
+
 ### Species names
 
 **Show species names** turns the labels on and off, same as **B** on the panel.

--- a/docs/display.md
+++ b/docs/display.md
@@ -57,6 +57,27 @@ The frame draws at most 40 species whatever you pick, so **No limit** means
 "everything the window heard, up to 40" - the 40 most heard, if it comes to
 that.
 
+### Bird size
+
+What decides how big each bird is drawn - and with it how central, since the
+bigger birds are laid down first, in the middle. Only the collage uses it.
+
+| Decided by | What you get |
+| --- | --- |
+| Real body size (default) | A swan is drawn bigger than a wren, from its real body mass |
+| Body size, and how often heard | The same, but the birds you hear most grow and move to the middle |
+
+The second is for when the page doesn't look like what you actually hear: a
+sparrow heard three hundred times a day drawn small, off in a corner, next to a
+heron that passed over once. Body size still has its say - the two pull about
+equally hard, so a swan does not shrink away for being quiet.
+
+**Redraw the panel for a size change** is there on the e-ink panel's behalf, so
+it is greyed out on a frame that has no panel. A refresh takes 20-30 seconds and
+you notice it happening, so by default the frame holds a size change back and
+lets it ride along with the next page that has a new bird on it. Pick a wait
+instead if you would rather see it sooner. The web view never waits either way.
+
 ### Species names
 
 **Show species names** turns the labels on and off, same as **B** on the panel.

--- a/src/fugleramme/modes.py
+++ b/src/fugleramme/modes.py
@@ -7,6 +7,10 @@ species set for the collage, the run the latest bird is on rather than its last
 call. The key is what makes a slow e-ink page bearable: a busy feeder must not
 spend the day refreshing.
 
+A key comes in two halves: `Mode.key` is the whole of it, `Mode.steady` the part
+that has to reach the glass at once. The difference is how often each bird has
+been heard, which drifts all day on its own - see `service._breathing`.
+
 Only the collage reads the lookback window; the rest look at the whole record,
 which is why the admin greys the setting out for them.
 """
@@ -30,6 +34,7 @@ from .picks import Picks
 from .render.collage import gather_entries, render_collage, selected_species
 from .render.page import day_ordinal
 from .render.plate import render_plate
+from .render.sizes import SIZE_BY_HEARD, count_tiers
 from .source import Source, Species
 
 if TYPE_CHECKING:
@@ -56,6 +61,7 @@ class Context:
     lookback_hours: int
     font_key: str
     label_size: str
+    size_by: str
     species_limit: int
     ranking: str
     textured: bool = True
@@ -90,6 +96,7 @@ def context(
         lookback_hours=settings.lookback_hours,
         font_key=settings.label_font,
         label_size=settings.label_size,
+        size_by=settings.size_by,
         species_limit=settings.species_limit,
         ranking=settings.ranking,
         textured=textured,
@@ -106,6 +113,8 @@ class Mode:
     # Driven by the lookback window: the admin offers the setting, and the loop
     # prunes artwork picks to it.
     windowed: bool = False
+    # The part of `key` that must reach the glass at once; None means all of it.
+    steady: Callable[[Context], tuple] | None = None
 
 
 def _plate(ctx: Context, name: str | None, note: str = "", art: Path | None = None) -> Image.Image:
@@ -125,8 +134,8 @@ def _plate(ctx: Context, name: str | None, note: str = "", art: Path | None = No
 
 
 def _selected(ctx: Context) -> list[str]:
-    """The species on the collage, in name order. Asked on every poll by the key
-    and the render alike, and cheap enough for it."""
+    """The species on the collage, in name order. Asked on every poll by the key,
+    the emphasis and the render alike, and cheap enough for it."""
     return selected_species(
         ctx.source,
         ctx.images_dir,
@@ -137,12 +146,35 @@ def _selected(ctx: Context) -> list[str]:
     )
 
 
-def _collage_key(ctx: Context) -> tuple:
+def _emphasis(ctx: Context) -> tuple[tuple[str, int], ...]:
+    """How often each species has been heard, in broad bands, or empty when the
+    frame sizes by body mass alone (the default) or is on a plate mode - those
+    draw one bird off the whole record, so there is nothing to band.
+
+    The one input to the page that moves on its own all day, and so the only
+    thing `_collage_key` has that `_collage_steady` does not.
+    """
+    if ctx.size_by != SIZE_BY_HEARD or not mode_of(ctx.mode).windowed:
+        return ()
+    # Banded against the birds on the page, not the window: the ten rarest are
+    # all quiet next to the resident crow, and would come out ten of a size.
+    on_page = set(_selected(ctx))
+    counted = [
+        (name, n) for name, n in ctx.source.species_since(ctx.lookback_hours) if name in on_page
+    ]
+    return tuple(sorted(count_tiers(counted).items()))
+
+
+def _collage_steady(ctx: Context) -> tuple:
     # The species actually on the page, in name order (no re-render when the
     # ranking reorders them). Not the window's: under a limit two birds trading
     # places across it change the picture while the window's own set sits still.
     species = tuple(_selected(ctx))
     return (species, day_ordinal() if not species else None)
+
+
+def _collage_key(ctx: Context) -> tuple:
+    return _collage_steady(ctx) + (_emphasis(ctx),)
 
 
 def _collage(ctx: Context) -> Image.Image:
@@ -163,6 +195,7 @@ def _collage(ctx: Context) -> Image.Image:
         ctx.label_size,
         ctx.namer.label,
         ctx.perches(),
+        dict(_emphasis(ctx)),
     )
 
 
@@ -248,6 +281,7 @@ MODES: dict[str, Mode] = {
         _collage_key,
         _collage_subjects,
         windowed=True,
+        steady=_collage_steady,
     ),
     "latest": Mode(
         "Latest bird",
@@ -265,10 +299,9 @@ def mode_of(key: str) -> Mode:
     return MODES.get(key, MODES[DEFAULT_MODE])
 
 
-def state_key(ctx: Context) -> tuple:
-    """Everything the page is a function of: the render cache key, and what the
-    kiosk polls to know the picture changed."""
-    mode = mode_of(ctx.mode)
+def _key(ctx: Context, mode_part: tuple) -> tuple:
+    """The settings half of a key, the mode's own half on the end. One builder for
+    both keys below, so they cannot drift apart in what they cover."""
     return (
         ctx.mode,
         ctx.style,
@@ -277,8 +310,22 @@ def state_key(ctx: Context) -> tuple:
         ctx.font_key,
         ctx.label_size,
         ctx.namer.key,
-        mode.key(ctx),
+        ctx.size_by,
+        mode_part,
     )
+
+
+def state_key(ctx: Context) -> tuple:
+    """Everything the page is a function of: the render cache key, and what the
+    kiosk polls to know the picture changed."""
+    return _key(ctx, mode_of(ctx.mode).key(ctx))
+
+
+def steady_key(ctx: Context) -> tuple:
+    """The part of `state_key` that may not be made to wait: equal here but not
+    there means the same birds at sizes that have drifted."""
+    mode = mode_of(ctx.mode)
+    return _key(ctx, (mode.steady or mode.key)(ctx))
 
 
 def token(key: tuple) -> str:

--- a/src/fugleramme/modes.py
+++ b/src/fugleramme/modes.py
@@ -27,7 +27,7 @@ from PIL import Image
 from .languages import Namer
 from .names import drawable_keys, image_for, normalize, perches_for, resolve
 from .picks import Picks
-from .render.collage import gather_entries, render_collage
+from .render.collage import gather_entries, render_collage, selected_species
 from .render.page import day_ordinal
 from .render.plate import render_plate
 from .source import Source, Species
@@ -56,6 +56,8 @@ class Context:
     lookback_hours: int
     font_key: str
     label_size: str
+    species_limit: int
+    ranking: str
     textured: bool = True
 
     def perches(self):
@@ -88,6 +90,8 @@ def context(
         lookback_hours=settings.lookback_hours,
         font_key=settings.label_font,
         label_size=settings.label_size,
+        species_limit=settings.species_limit,
+        ranking=settings.ranking,
         textured=textured,
     )
 
@@ -120,15 +124,38 @@ def _plate(ctx: Context, name: str | None, note: str = "", art: Path | None = No
     )
 
 
+def _selected(ctx: Context) -> list[str]:
+    """The species on the collage, in name order. Asked on every poll by the key
+    and the render alike, and cheap enough for it."""
+    return selected_species(
+        ctx.source,
+        ctx.images_dir,
+        ctx.style,
+        ctx.lookback_hours,
+        ctx.species_limit,
+        ctx.ranking,
+    )
+
+
 def _collage_key(ctx: Context) -> tuple:
-    # Sorted to keep key constant for the same bird set (avoid re-renders on order change)
-    species = tuple(sorted(name for name, _ in ctx.source.species_since(ctx.lookback_hours)))
+    # The species actually on the page, in name order (no re-render when the
+    # ranking reorders them). Not the window's: under a limit two birds trading
+    # places across it change the picture while the window's own set sits still.
+    species = tuple(_selected(ctx))
     return (species, day_ordinal() if not species else None)
 
 
 def _collage(ctx: Context) -> Image.Image:
     return render_collage(
-        gather_entries(ctx.source, ctx.images_dir, ctx.style, ctx.picks, ctx.lookback_hours),
+        gather_entries(
+            ctx.source,
+            ctx.images_dir,
+            ctx.style,
+            ctx.picks,
+            ctx.lookback_hours,
+            ctx.species_limit,
+            ctx.ranking,
+        ),
         ctx.resolution,
         ctx.show_names,
         ctx.textured,
@@ -202,14 +229,26 @@ def _one(species) -> list[str]:
 
 
 def _collage_subjects(ctx: Context) -> list[str]:
-    # The whole window, art-less species included: the admin marks those as
-    # counted but not drawn.
-    return [name for name, _ in ctx.source.species_since(ctx.lookback_hours)]
+    """What is on the page, plus every species the window counted that this style
+    cannot draw - the admin marks those as counted but not drawn (#9), which is
+    how a missing plate gets reported. Species the limit left out are not listed:
+    that is not a gap in the frame, it is the admin asking for a shorter page.
+    """
+    keys = ctx.drawable()
+    counted = ctx.source.species_since(ctx.lookback_hours)
+    artless = [name for name, _ in counted if normalize(name) not in keys]
+    return sorted(_selected(ctx) + artless)
 
 
 # Insertion order is the order button A walks.
 MODES: dict[str, Mode] = {
-    "collage": Mode("Collage (default)", _collage, _collage_key, _collage_subjects, windowed=True),
+    "collage": Mode(
+        "Collage (default)",
+        _collage,
+        _collage_key,
+        _collage_subjects,
+        windowed=True,
+    ),
     "latest": Mode(
         "Latest bird",
         _latest_page,

--- a/src/fugleramme/render/collage.py
+++ b/src/fugleramme/render/collage.py
@@ -13,6 +13,9 @@ names are off). The name label is an admin toggle, on by default, and reads in
 the admin's chosen language(s); it packs as part of its bird, tucked up under
 the silhouette, so a name can never land on a neighbour or clip.
 
+Size and centrality are one number, not two: whatever makes a bird bigger also
+places it earlier on the spiral. What feeds that number is sizes.py's business.
+
 Nothing here rolls dice per render: a species holds its artwork for as long as
 it is in the window (picks.py) and the mirror is a hash of the name, so a bird
 is unaffected by which other birds are on the page, or by a restart.
@@ -24,7 +27,7 @@ import hashlib
 import logging
 import math
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -46,7 +49,7 @@ from .page import (
     trim,
 )
 from .paper import PAD, process_sprite
-from .sizes import SIZE_EXPONENT, mass_of
+from .sizes import SIZE_EXPONENT, TIER_STEP, mass_of
 
 log = logging.getLogger(__name__)
 
@@ -221,12 +224,26 @@ def _flip(name: str) -> bool:
     return hashlib.blake2b(name.encode(), digest_size=1).digest()[0] < 128
 
 
-def _size_weights(names: list[str]) -> list[float]:
-    """Per-bird display weight from real mass, centered on the present set's
-    geometric mean and compressed by SIZE_EXPONENT."""
+def _geometric(values: list[float]) -> float:
+    return math.exp(sum(math.log(v) for v in values) / len(values))
+
+
+def _size_weights(names: list[str], tiers: Mapping[str, int]) -> list[float]:
+    """Per-bird display weight from real mass, optionally multiplied by how often
+    the bird has been heard (`tiers`; empty means mass alone).
+
+    Each factor is divided by the set's geometric mean, so it only ever says how
+    a bird compares to its neighbours. That is what keeps the two composable and
+    keeps `base`, which sizes the cluster to the page, from drifting.
+    """
     masses = [mass_of(n) for n in names]
-    geo = math.exp(sum(math.log(m) for m in masses) / len(masses))
-    return [(m / geo) ** SIZE_EXPONENT for m in masses]
+    geo = _geometric(masses)
+    weights = [(m / geo) ** SIZE_EXPONENT for m in masses]
+    if not tiers:
+        return weights
+    heard = [float(TIER_STEP ** tiers.get(n, 0)) for n in names]
+    loud = _geometric(heard)
+    return [w * h / loud for w, h in zip(weights, heard, strict=True)]
 
 
 def _layout(
@@ -291,6 +308,7 @@ def _placements(
     key: tuple,
     arts: list[Image.Image],
     names: list[str],
+    tiers: Mapping[str, int],
     flips: list[bool],
     width: int,
     height: int,
@@ -307,10 +325,11 @@ def _placements(
         if hit is not None:
             return hit
 
-        # Each bird's target size scales with its real mass (compressed); the whole
-        # set then overshoots and shrinks to the first fit that fills the canvas.
-        # Placing biggest-first on the center-out spiral keeps large birds central.
-        weights = _size_weights(names)
+        # Each bird's target size scales with its real mass (compressed), and
+        # optionally with how often it was heard; the whole set then overshoots
+        # and shrinks to the first fit. Biggest-first on the spiral keeps the
+        # birds that earned the most size central.
+        weights = _size_weights(names, tiers)
         order = sorted(range(len(names)), key=lambda i: -weights[i])
         base = min(
             math.sqrt(width * height * 1.5 / sum(w * w for w in weights)),
@@ -358,6 +377,7 @@ def render_collage(
     label_size: str = fonts.DEFAULT_LABEL_SIZE,
     label_text: Callable[[str], str] = str,
     perches: Sequence[Path] = (),
+    tiers: Mapping[str, int] | None = None,
 ) -> Image.Image:
     """Composite the given (name, image) entries into a tightly packed collage.
 
@@ -365,6 +385,8 @@ def render_collage(
     would otherwise turn the grain into noise. It also picks the label ink.
     label_text: scientific name -> what the label reads; str leaves it alone.
     perches: the active style's bare branches, for a page with no birds on it.
+    tiers: how often each species was heard, in bands (sizes.count_tiers);
+    empty sizes the page by body mass alone, which is the default.
     """
     canvas = blank(resolution, textured)
 
@@ -379,6 +401,8 @@ def render_collage(
     width, height = round(resolution[0] / scale), round(resolution[1] / scale)
 
     names = [name for name, _ in kept]
+    # Narrowed to the birds actually drawn; the window's bands cover more.
+    heard = {name: tiers[name] for name in names if name in tiers} if tiers else {}
     flips = [_flip(name) for name in names]
     name_px = label_px(width, height, label_size)
     labels = tuple(label_text(name) for name in names) if show_names else None
@@ -389,11 +413,14 @@ def render_collage(
         font_key if show_names else None,
         name_px,
         labels,
+        # In the key because they change the sizes, and so the whole packing.
+        tuple(sorted(heard.items())),
     )
     placed, used_px = _placements(
         key,
         arts,
         names,
+        heard,
         flips,
         width,
         height,

--- a/src/fugleramme/render/collage.py
+++ b/src/fugleramme/render/collage.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import numpy as np
 from PIL import Image, ImageFilter
 
-from ..names import image_for
+from ..names import drawable_keys, image_for, normalize
 from ..picks import Picks
 from ..source import Source
 from . import fonts
@@ -56,7 +56,21 @@ DEFAULT_RESOLUTION = (1280, 800)
 # panel and the kiosk on different pages.
 _PACK_SHORT = 1200
 _MARGIN = 0.04  # page edge to content on short side. Hardcoded now, maybe add configurability?
-_MAX_BIRDS = 40  # keeps the render quick, not the page tidy
+# The frame's own ceiling whatever the admin asks for: a render is ~90% packing
+# and the Pi has to finish it. Keeps the render quick, not the page tidy.
+MAX_BIRDS = 40
+
+# How many species the admin lets on, and which ones (#53). NO_LIMIT still means
+# "every bird the window holds", not "however long the Pi takes to draw them".
+NO_LIMIT = 0
+LIMIT_OPTIONS = (NO_LIMIT, 5, 8, 10, 12, 15, 20, 30)
+RANK_MOST_HEARD = "heard"
+RANK_RAREST = "rarest"
+RANKINGS = {
+    RANK_MOST_HEARD: "The most heard",
+    RANK_RAREST: "The rarest",  # at a busy station the visitor is the interesting one
+}
+DEFAULT_RANKING = RANK_MOST_HEARD
 _ALPHA_CUTOFF = 24
 _OVERLAP_PX = 2  # erode the collision mask slightly so birds nestle into
 # each other's (invisible on paper) halos. No rotation:
@@ -354,7 +368,7 @@ def render_collage(
     """
     canvas = blank(resolution, textured)
 
-    kept = [(name, path) for name, path in entries if path is not None][:_MAX_BIRDS]
+    kept = [(name, path) for name, path in entries if path is not None][:MAX_BIRDS]
     if not kept:
         draw_perch(canvas, perches, day_ordinal(), textured)
         return canvas
@@ -413,19 +427,57 @@ def _at(at: tuple[int, int], scale: float) -> tuple[int, int]:
     return round(at[0] * scale), round(at[1] * scale)
 
 
+def _rank(ranking: str):
+    """Sort key that puts the birds the admin asked to keep first. Ties break on
+    the name, so a page at its limit does not flicker between two equal birds."""
+    if ranking == RANK_RAREST:
+        return lambda pair: (pair[1], pair[0])
+    return lambda pair: (-pair[1], pair[0])
+
+
+def selected_species(
+    source: Source,
+    images_dir: Path,
+    style: str,
+    hours: int = 24,
+    limit: int = NO_LIMIT,
+    ranking: str = DEFAULT_RANKING,
+) -> list[str]:
+    """The species that make the page, in name order.
+
+    Name order because the order birds are handed over must not depend on their
+    counts - a bird merely heard again would reshuffle the whole packing. Which
+    birds are on it does depend on the counts once a limit is set, so the page's
+    key is built from this same list.
+
+    The ranking only applies under a limit, as the admin says: with none set the
+    frame's own ceiling keeps the most heard, whatever the greyed-out field holds.
+
+    What the style cannot draw is dropped before the limit, so a plate the frame
+    does not have never takes one of the places. One directory listing, not a
+    probe per species: the loop asks for this on every poll, and so does the
+    kiosk.
+    """
+    keys = drawable_keys(images_dir, style)
+    counted = [(name, n) for name, n in source.species_since(hours) if normalize(name) in keys]
+    if limit == NO_LIMIT:
+        limit, ranking = MAX_BIRDS, DEFAULT_RANKING
+    ranked = sorted(counted, key=_rank(ranking))
+    return sorted(name for name, _n in ranked[: min(limit, MAX_BIRDS)])
+
+
 def gather_entries(
     source: Source,
     images_dir: Path,
     style: str,
     picks: Picks,
     hours: int = 24,
+    limit: int = NO_LIMIT,
+    ranking: str = DEFAULT_RANKING,
 ) -> list[tuple[str, Path | None]]:
-    """Recent-window species paired with the artwork each is wearing, or None.
-
-    In name order, matching the collage's cache key: the page is a function of
-    the species set alone, so a count moving must not reshuffle the layout.
-    """
+    """The page's species paired with the artwork each is wearing. The None only
+    stands for a file that vanished between `selected_species` and here."""
     return [
         (name, image_for(name, images_dir, style, picks))
-        for name, _count in sorted(source.species_since(hours))
+        for name in selected_species(source, images_dir, style, hours, limit, ranking)
     ]

--- a/src/fugleramme/render/sizes.py
+++ b/src/fugleramme/render/sizes.py
@@ -1,15 +1,18 @@
-"""Real-world bird size, used to scale birds in the collage.
+"""How big a bird is drawn, and so how central it lands on the page.
 
-Body mass (grams) per species from AVONET (Tobias et al. 2022, Ecology Letters,
-CC BY 4.0), vendored as `assets/bird_sizes.csv` keyed by eBird scientific name.
-AVONET has no body-length column, so mass is the size metric; the collage
-compresses it with a fractional exponent (see SIZE_EXPONENT) so big birds read
-bigger without small ones vanishing.
+`Settings.size_by` picks what decides it: real body mass alone, or mass times
+how often the species was actually heard. Body mass (grams) per species from
+AVONET (Tobias et al. 2022, Ecology Letters, CC BY 4.0), vendored as
+`assets/bird_sizes.csv` keyed by eBird scientific name; AVONET has no
+body-length column, so mass is the size metric. Both inputs are compressed hard
+on their way to the page - it is an illustrated plate, not a chart.
 """
 
 from __future__ import annotations
 
 import csv
+import math
+from collections.abc import Iterable
 
 from ..config import REPO_ROOT
 from ..names import normalize
@@ -18,6 +21,23 @@ from ..names import normalize
 # compression: 0 = all equal, 1 = proportional to mass. ~0.14 makes the
 # heaviest species roughly 2.5x the lightest, linearly.
 SIZE_EXPONENT = 0.14
+
+# Stored in settings.json, so renaming a value resets every frame that had it.
+SIZE_BY_MASS = "mass"
+SIZE_BY_HEARD = "heard"
+SIZE_BY_OPTIONS = {
+    SIZE_BY_MASS: "Real body size",
+    SIZE_BY_HEARD: "Body size, and how often heard",
+}
+DEFAULT_SIZE_BY = SIZE_BY_MASS
+
+# Each band up multiplies display size by this, so top to bottom is ~2.6x -
+# level with SIZE_EXPONENT's ~2.5x, so neither input can flatten the other.
+TIER_STEP = 1.6
+
+# Band edges in halvings below the busiest species: within ~2.8x of it is the
+# top band, within ~16x the middle. Wide on purpose, see `count_tiers`.
+_BAND_EDGES = (1.5, 4.0)
 
 _SIZES_CSV = REPO_ROOT / "assets" / "bird_sizes.csv"
 
@@ -37,3 +57,21 @@ _MEDIAN = sorted(_MASS.values())[len(_MASS) // 2] if _MASS else 1.0
 def mass_of(scientific_name: str) -> float:
     """Body mass in grams, or the dataset median for an unknown species."""
     return _MASS.get(normalize(scientific_name), _MEDIAN)
+
+
+def count_tiers(counts: Iterable[tuple[str, int]]) -> dict[str, int]:
+    """Species to a broad "how often heard" band, 2 = busiest, 0 = quietest.
+
+    Bands, never the count itself: the layout is a function of its cache key and
+    the loop repaints when that key moves, so a raw count would repack the page
+    on every single detection. Measured against the busiest species rather than
+    fixed numbers, so a band means the same at a quiet feeder and a loud one.
+    """
+    tally = {name: count for name, count in counts if count > 0}
+    if not tally:
+        return {}
+    top = max(tally.values())
+    return {
+        name: len(_BAND_EDGES) - sum(math.log2(top / count) >= edge for edge in _BAND_EDGES)
+        for name, count in tally.items()
+    }

--- a/src/fugleramme/service.py
+++ b/src/fugleramme/service.py
@@ -6,6 +6,10 @@ colors. The loop re-renders the panel image only when the mode's own key changes
 - see modes.py - a natural debounce for the slow e-ink refresh. The web view
 renders fresh per request, at the panel's shape and its own pixel count.
 
+`_breathing` is the second debounce, and the glass's alone: a page differing
+only in how loud each bird has been may be made to wait out the admin's breath.
+A frame with no panel never breathes, so web-only is as live as it ever was.
+
 Panel-absent is not a special case: init_panel returns None and we skip the
 push, the same path as the preview.
 """
@@ -33,6 +37,19 @@ from .web.server import serve
 log = logging.getLogger(__name__)
 
 _POLL_SECONDS = 5  # one query per tick; re-renders only on change, so e-ink stays the bottleneck
+
+
+def _breathing(steady: tuple, last: tuple | None, painted_at: float, minutes: int) -> bool:
+    """True when the page has moved only in how often the birds have been heard,
+    and the panel has not held the current one long enough yet.
+
+    Only that ever waits: a new species, a settings change and a button press all
+    move the steady key and go straight to the glass. 0 turns it off; the default
+    WITH_THE_BIRDS is negative and lets go only when the birds themselves change.
+    """
+    if last is None or minutes == 0 or steady != last:
+        return False
+    return minutes < 0 or time.monotonic() - painted_at < minutes * 60
 
 
 def detector(config: Config) -> tuple[SettingsStore, Configured]:
@@ -109,6 +126,8 @@ def run(config: Config) -> None:
     log.info("Reading detections from %s", source.base_url)
 
     last_key: tuple | None = None
+    last_steady: tuple | None = None
+    painted_at = 0.0
     pending = None  # rendered but not yet on the glass; survives a failed push
     unreachable = False
     while True:
@@ -131,16 +150,26 @@ def run(config: Config) -> None:
         try:
             key = (modes.state_key(ctx), settings.rotation)
             if key != last_key:
-                if modes.mode_of(ctx.mode).windowed:
-                    # The loop owns the window, so it is the only caller that may forget
-                    # a departed bird's artwork - the kiosk may be previewing another one.
-                    picks.retain(name for name, _ in source.species_since(settings.lookback_hours))
-                panel_image = dither(modes.render(ctx))
-                panel_image.save(config.output_path)
-                log.info("Rendered %s page at %dx%d", ctx.mode, *size)
-                status.rendered()
-                last_key = key
-                pending = (panel_image, settings.rotation) if panel is not None else None
+                steady = (modes.steady_key(ctx), settings.rotation)
+                # No panel, no slow refresh to protect, so nothing to wait for.
+                breath = settings.breath_minutes if panel is not None else 0
+                if _breathing(steady, last_steady, painted_at, breath):
+                    # last_key stays put: the change is deferred, not dropped.
+                    log.debug("Holding the page: only the emphasis moved")
+                else:
+                    if modes.mode_of(ctx.mode).windowed:
+                        # The loop owns the window, so it is the only caller that may forget
+                        # a departed bird's artwork - the kiosk may be previewing another one.
+                        picks.retain(
+                            name for name, _ in source.species_since(settings.lookback_hours)
+                        )
+                    panel_image = dither(modes.render(ctx))
+                    panel_image.save(config.output_path)
+                    log.info("Rendered %s page at %dx%d", ctx.mode, *size)
+                    status.rendered()
+                    last_key, last_steady = key, steady
+                    painted_at = time.monotonic()
+                    pending = (panel_image, settings.rotation) if panel is not None else None
             if unreachable:
                 log.info("Detector reachable again")
                 unreachable = False

--- a/src/fugleramme/settings.py
+++ b/src/fugleramme/settings.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from .config import DEFAULT_DETECTOR_URL, DEFAULT_WEB_RESOLUTION, WEB_HEIGHTS
 from .languages import NONE, SCIENTIFIC
 from .modes import DEFAULT_MODE, MODES
+from .render.collage import DEFAULT_RANKING, MAX_BIRDS, NO_LIMIT, RANKINGS
 from .render.fonts import DEFAULT_FONT, DEFAULT_LABEL_SIZE, FONTS, LABEL_SIZES
 
 # How the frame hangs, counter-clockwise. 0/180 render landscape, 90/270 portrait.
@@ -54,6 +55,9 @@ class Settings:
     # Shapes both outputs; only the panel actually turns the pixels.
     rotation: int = 0
     lookback_hours: int = 24
+    # Which birds make the page (#53); no limit leaves an existing frame alone.
+    species_limit: int = NO_LIMIT
+    ranking: str = DEFAULT_RANKING
     # Active artwork style folder; empty means "whichever is present" (resolved
     # against the filesystem at render time, so it survives a renamed style).
     style: str = ""
@@ -159,6 +163,8 @@ def _coerce(raw: dict, base: Settings | None = None) -> Settings:
         ),
         rotation=_one_of(rotation, ROTATIONS, d.rotation),
         lookback_hours=_as_int(raw.get("lookback_hours"), d.lookback_hours, ALL_TIME, 24 * 30),
+        species_limit=_as_int(raw.get("species_limit"), d.species_limit, NO_LIMIT, MAX_BIRDS),
+        ranking=_one_of(str(raw.get("ranking", d.ranking)), RANKINGS, d.ranking),
         style=_style(raw, d.style),
         auto_update=_as_bool(raw.get("auto_update"), d.auto_update),
         show_names=_as_bool(raw.get("show_names"), d.show_names),

--- a/src/fugleramme/settings.py
+++ b/src/fugleramme/settings.py
@@ -22,6 +22,7 @@ from .languages import NONE, SCIENTIFIC
 from .modes import DEFAULT_MODE, MODES
 from .render.collage import DEFAULT_RANKING, MAX_BIRDS, NO_LIMIT, RANKINGS
 from .render.fonts import DEFAULT_FONT, DEFAULT_LABEL_SIZE, FONTS, LABEL_SIZES
+from .render.sizes import DEFAULT_SIZE_BY, SIZE_BY_OPTIONS
 
 # How the frame hangs, counter-clockwise. 0/180 render landscape, 90/270 portrait.
 ROTATIONS = (0, 90, 180, 270)
@@ -40,6 +41,23 @@ LOOKBACK_OPTIONS = (
     (720, "Last 30 days"),
     (ALL_TIME, "All time"),
 )
+
+
+# How long the panel holds a page before a size change alone may repaint it
+# (`service._breathing`). The default holds until the birds themselves change,
+# which is the panel's rule (discussion #37): a refresh you notice should mean
+# the frame actually heard a new bird.
+WITH_THE_BIRDS = -1
+BREATH_OPTIONS = (
+    (WITH_THE_BIRDS, "Only when the birds change"),
+    (0, "Straight away"),
+    (5, "After 5 minutes"),
+    (15, "After 15 minutes"),
+    (30, "After 30 minutes"),
+    (60, "After 1 hour"),
+    (180, "After 3 hours"),
+)
+DEFAULT_BREATH_MINUTES = WITH_THE_BIRDS
 
 
 def lookback_order(hours: int) -> float:
@@ -61,6 +79,9 @@ class Settings:
     # Active artwork style folder; empty means "whichever is present" (resolved
     # against the filesystem at render time, so it survives a renamed style).
     style: str = ""
+    # What the collage sizes and centres birds by; only the collage reads it.
+    size_by: str = DEFAULT_SIZE_BY
+    breath_minutes: int = DEFAULT_BREATH_MINUTES
     auto_update: bool = False
     show_names: bool = True
     # Species-name languages: BirdNET-Go dictionary locales, resolved
@@ -166,6 +187,10 @@ def _coerce(raw: dict, base: Settings | None = None) -> Settings:
         species_limit=_as_int(raw.get("species_limit"), d.species_limit, NO_LIMIT, MAX_BIRDS),
         ranking=_one_of(str(raw.get("ranking", d.ranking)), RANKINGS, d.ranking),
         style=_style(raw, d.style),
+        size_by=_one_of(str(raw.get("size_by", d.size_by)), SIZE_BY_OPTIONS, d.size_by),
+        breath_minutes=_as_int(
+            raw.get("breath_minutes"), d.breath_minutes, WITH_THE_BIRDS, 24 * 60
+        ),
         auto_update=_as_bool(raw.get("auto_update"), d.auto_update),
         show_names=_as_bool(raw.get("show_names"), d.show_names),
         # A primary language is required: an empty pick means the scientific name.

--- a/src/fugleramme/web/admin.py
+++ b/src/fugleramme/web/admin.py
@@ -20,6 +20,7 @@ from ..config import BIRDNET_PORT, DOCS_URL, WEB_HEIGHTS
 from ..languages import NONE, Namer, catalog, catalog_failure, ordered
 from ..modes import MODES
 from ..names import available_styles, image_for, origin_of, source_of
+from ..render.collage import LIMIT_OPTIONS, MAX_BIRDS, NO_LIMIT, RANKINGS
 from ..render.fonts import FONTS, LABEL_SIZES
 from ..settings import LOOKBACK_OPTIONS, ROTATIONS, Settings, lookback_order, merged
 from ..source import NEEDS_PASSWORD, Unavailable
@@ -303,6 +304,31 @@ def _lookbacks(settings: Settings) -> str:
     return _options(sorted(labels, key=lookback_order), settings.lookback_hours, labels.get)
 
 
+def _limits(settings: Settings) -> str:
+    # A hand-edited non-preset value stays selectable so Save doesn't drop it.
+    labels = {n: ("No limit" if n == NO_LIMIT else f"{n} species") for n in LIMIT_OPTIONS}
+    labels.setdefault(settings.species_limit, f"{settings.species_limit} species")
+    return _options(sorted(labels), settings.species_limit, labels.get)
+
+
+def _species_field(settings: Settings) -> str:
+    """How many species the collage shows, and which ones it keeps (#53).
+
+    "No limit" still names MAX_BIRDS, because that is the honest answer: it is
+    the render budget and no setting spends past it. admin.js greys the ranking
+    out until there is a limit, with nothing to choose between before that.
+    """
+    return (
+        f'<div class="field" id="limit">'
+        f"<span>Species on the page <small>(at most {MAX_BIRDS})</small></span>"
+        f'<label class="sub"><small>How many</small><select name="species_limit">'
+        f"{_limits(settings)}</select></label>"
+        f'<label class="sub" id="ranking"><small>Which ones to keep</small>'
+        f'<select name="ranking">{_options(RANKINGS, settings.ranking, RANKINGS.get)}</select>'
+        f"</label></div>"
+    )
+
+
 def page(
     ctx: modes.Context,
     settings: Settings,
@@ -342,6 +368,7 @@ def page(
                 "birdnetPort": birdnet_port,
                 "version": __version__,
                 "windowedModes": [k for k, m in MODES.items() if m.windowed],
+                "noLimit": str(NO_LIMIT),
             }
         ),
         mode_field=(
@@ -359,6 +386,7 @@ def page(
         lookback_off="" if windowed else ' class="off"',
         lookback_disabled="" if windowed else " disabled",
         lookbacks=_lookbacks(settings),
+        limit_field=_species_field(settings),
         names_field=_names_field(settings, languages, names_failure),
         style_field=(
             f'<div class="field"><span>Artwork style</span>'

--- a/src/fugleramme/web/admin.py
+++ b/src/fugleramme/web/admin.py
@@ -22,7 +22,15 @@ from ..modes import MODES
 from ..names import available_styles, image_for, origin_of, source_of
 from ..render.collage import LIMIT_OPTIONS, MAX_BIRDS, NO_LIMIT, RANKINGS
 from ..render.fonts import FONTS, LABEL_SIZES
-from ..settings import LOOKBACK_OPTIONS, ROTATIONS, Settings, lookback_order, merged
+from ..render.sizes import SIZE_BY_HEARD, SIZE_BY_OPTIONS
+from ..settings import (
+    BREATH_OPTIONS,
+    LOOKBACK_OPTIONS,
+    ROTATIONS,
+    Settings,
+    lookback_order,
+    merged,
+)
 from ..source import NEEDS_PASSWORD, Unavailable
 from ..status import Status
 from . import STATIC_DIR, hostinfo
@@ -329,6 +337,28 @@ def _species_field(settings: Settings) -> str:
     )
 
 
+def _breaths(settings: Settings) -> str:
+    # Declaration order, not numeric: the longest wait of all is a negative
+    # number. A hand-edited value stays selectable so Save doesn't drop it.
+    labels = dict(BREATH_OPTIONS)
+    labels.setdefault(settings.breath_minutes, f"After {settings.breath_minutes} minutes")
+    return _options(labels, settings.breath_minutes, labels.get)
+
+
+def _emphasis_field(settings: Settings) -> str:
+    """What the collage sizes birds by, and how central it therefore puts them.
+    The breath sits under it because it exists only for the second option;
+    admin.js greys it out for the first, and on a frame with no panel."""
+    return (
+        f'<div class="field" id="emphasis"><span>Bird size <small>(and how central)</small></span>'
+        f'<label class="sub"><small>Decided by</small><select name="size_by">'
+        f"{_options(SIZE_BY_OPTIONS, settings.size_by, SIZE_BY_OPTIONS.get)}</select></label>"
+        f'<label class="sub" id="breath"><small>Redraw the panel for a size change</small>'
+        f'<select name="breath_minutes">{_breaths(settings)}</select></label>'
+        f"</div>"
+    )
+
+
 def page(
     ctx: modes.Context,
     settings: Settings,
@@ -368,7 +398,9 @@ def page(
                 "birdnetPort": birdnet_port,
                 "version": __version__,
                 "windowedModes": [k for k, m in MODES.items() if m.windowed],
+                "sizeByHeard": SIZE_BY_HEARD,
                 "noLimit": str(NO_LIMIT),
+                "panel": detected,
             }
         ),
         mode_field=(
@@ -387,6 +419,7 @@ def page(
         lookback_disabled="" if windowed else " disabled",
         lookbacks=_lookbacks(settings),
         limit_field=_species_field(settings),
+        emphasis_field=_emphasis_field(settings),
         names_field=_names_field(settings, languages, names_failure),
         style_field=(
             f'<div class="field"><span>Artwork style</span>'

--- a/src/fugleramme/web/static/admin.css
+++ b/src/fugleramme/web/static/admin.css
@@ -28,7 +28,7 @@ label.src input { width: auto; padding: 0; }
 button { font-size: 1rem; padding: 0.5rem 1.25rem; margin-top: 0.5rem; }
 button:disabled { opacity: 0.45; }
 /* A setting the chosen mode does not read: shown, so its value is not a surprise on the way back. */
-label.off { opacity: 0.45; }
+label.off, .field.off { opacity: 0.45; }
 a { color: #446; }
 dl.status { display: grid; grid-template-columns: auto 1fr; gap: 0.35rem 1rem;
             background: #f4f2ee; padding: 1rem 1.25rem; border-radius: 6px; margin: 0 0 1.75rem; }

--- a/src/fugleramme/web/static/admin.html
+++ b/src/fugleramme/web/static/admin.html
@@ -27,6 +27,7 @@
       <span>Lookback window <small>(how far back the frame looks)</small></span>
       <select name="lookback_hours"$lookback_disabled>$lookbacks</select></label>
     $limit_field
+    $emphasis_field
     $names_field
     $style_field
     <button type="submit">Save</button>

--- a/src/fugleramme/web/static/admin.html
+++ b/src/fugleramme/web/static/admin.html
@@ -26,6 +26,7 @@
     <label id="lookback"$lookback_off>
       <span>Lookback window <small>(how far back the frame looks)</small></span>
       <select name="lookback_hours"$lookback_disabled>$lookbacks</select></label>
+    $limit_field
     $names_field
     $style_field
     <button type="submit">Save</button>

--- a/src/fugleramme/web/static/admin.js
+++ b/src/fugleramme/web/static/admin.js
@@ -165,6 +165,8 @@ async function loadSpecies(query, id) {
 const lookback = document.getElementById("lookback");
 const limit = document.getElementById("limit");
 const ranking = document.getElementById("ranking");
+const emphasis = document.getElementById("emphasis");
+const breath = document.getElementById("breath");
 function dim(el, on) {
   el.querySelectorAll("select").forEach((s) => { s.disabled = !on; });
   el.classList.toggle("off", !on);
@@ -174,9 +176,15 @@ function syncMode() {
   const on = !mode || cfg.windowedModes.includes(mode.value);
   dim(lookback, on);
   dim(limit, on);
+  dim(emphasis, on);
   // Nothing to rank while every bird the window heard is already on the page.
   const capped = form.querySelector("select[name=species_limit]").value !== cfg.noLimit;
   dim(ranking, on && capped);
+  // The breath only holds back a size that drifts, so sizing by body mass -
+  // which never drifts - has nothing for it to hold. Nor has a frame with no
+  // panel: it is the slow e-ink refresh that the wait is buying.
+  const heard = form.querySelector("select[name=size_by]").value === cfg.sizeByHeard;
+  dim(breath, on && heard && cfg.panel);
 }
 
 // Capture, so a mode change settles which fields still submit before the shared

--- a/src/fugleramme/web/static/admin.js
+++ b/src/fugleramme/web/static/admin.js
@@ -163,11 +163,20 @@ async function loadSpecies(query, id) {
 // Settings the chosen mode ignores go dim and stop being submitted, so the
 // saved value survives a trip through a mode that has no use for it.
 const lookback = document.getElementById("lookback");
+const limit = document.getElementById("limit");
+const ranking = document.getElementById("ranking");
+function dim(el, on) {
+  el.querySelectorAll("select").forEach((s) => { s.disabled = !on; });
+  el.classList.toggle("off", !on);
+}
 function syncMode() {
   const mode = form.querySelector("input[name=mode]:checked");
   const on = !mode || cfg.windowedModes.includes(mode.value);
-  lookback.querySelector("select").disabled = !on;
-  lookback.classList.toggle("off", !on);
+  dim(lookback, on);
+  dim(limit, on);
+  // Nothing to rank while every bird the window heard is already on the page.
+  const capped = form.querySelector("select[name=species_limit]").value !== cfg.noLimit;
+  dim(ranking, on && capped);
 }
 
 // Capture, so a mode change settles which fields still submit before the shared

--- a/tests/test_emphasis.py
+++ b/tests/test_emphasis.py
@@ -1,0 +1,181 @@
+"""Sizing the page by how often each bird has actually been heard.
+
+The frame's default is unchanged - real body mass decides how big a bird is
+drawn and so how central it lands. This is the other option, and most of what
+matters about it is restraint: bands rather than counts, so the layout does not
+move on every detection, and a breath on top of the bands, so the panel is not
+asked to refresh over a bird drifting across an edge.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+import pytest
+from PIL import Image
+
+from fugleramme import service
+from fugleramme.render import collage
+from fugleramme.render.sizes import SIZE_BY_MASS, TIER_STEP, count_tiers
+from fugleramme.settings import WITH_THE_BIRDS, Settings
+
+QUIET, MIDDLE, LOUD = "Aaa aaa", "Bbb bbb", "Ccc ccc"
+
+
+@pytest.fixture(autouse=True)
+def _no_cached_layouts():
+    collage._layouts.clear()
+
+
+# --- the bands --------------------------------------------------------------
+
+
+def test_the_busiest_species_defines_the_top_band():
+    bands = count_tiers([("a", 200), ("b", 80), ("c", 30), ("d", 12), ("e", 1)])
+    assert bands["a"] == bands["b"] == 2
+    assert bands["c"] == 1
+    assert bands["d"] == bands["e"] == 0
+
+
+def test_the_bands_read_the_same_at_a_quiet_feeder_and_a_loud_one():
+    # Relative to the busiest species, so a garden with ten times the traffic
+    # does not simply put every bird in the top band.
+    quiet = count_tiers([("a", 20), ("b", 3), ("c", 1)])
+    loud = count_tiers([("a", 2000), ("b", 300), ("c", 100)])
+    assert quiet == loud
+
+
+def test_one_more_detection_never_moves_a_band():
+    """The point of bands. The layout is a function of its key and the loop
+    repaints when that key moves, so counts in the key would mean e-ink all day.
+    """
+    before = count_tiers([("a", 60), ("b", 20), ("c", 4)])
+    assert count_tiers([("a", 61), ("b", 20), ("c", 4)]) == before
+    assert count_tiers([("a", 60), ("b", 21), ("c", 4)]) == before
+    assert count_tiers([("a", 60), ("b", 20), ("c", 5)]) == before
+
+
+def test_a_species_heard_nothing_of_is_not_banded():
+    assert count_tiers([]) == {}
+    assert count_tiers([("a", 0)]) == {}
+    assert count_tiers([("a", 4), ("b", 0)]) == {"a": 2}
+
+
+# --- the weights ------------------------------------------------------------
+
+
+def test_the_bands_multiply_the_mass_weights_without_moving_their_average(monkeypatch):
+    """Every factor is divided by the set's geometric mean, which is what keeps
+    `base` - the number that sizes the cluster to the page - from drifting."""
+    names = [QUIET, MIDDLE, LOUD]
+    monkeypatch.setattr(collage, "mass_of", lambda name: 40.0)
+    bands = {QUIET: 0, MIDDLE: 1, LOUD: 2}
+
+    plain = collage._size_weights(names, {})
+    weighted = collage._size_weights(names, bands)
+
+    assert plain == [pytest.approx(1.0)] * 3
+    assert collage._geometric(weighted) == pytest.approx(1.0)
+    assert weighted[2] / weighted[0] == pytest.approx(TIER_STEP**2)
+
+
+def test_body_mass_still_has_its_say(monkeypatch):
+    # A loud wren does not outgrow a quiet swan by two bands alone; the two
+    # inputs multiply, they do not replace each other. They are tuned to about
+    # the same strength, though, so it takes a real swan to win: three orders of
+    # magnitude of mass against the full two bands.
+    masses = {QUIET: 10_000.0, LOUD: 5.0}
+    monkeypatch.setattr(collage, "mass_of", masses.get)
+    weights = collage._size_weights([QUIET, LOUD], {QUIET: 0, LOUD: 2})
+    assert weights[0] > weights[1]
+
+
+# --- what it does to the page ----------------------------------------------
+
+
+def _placed(names: list[str], bands: dict[str, int], size: tuple[int, int] = (1200, 900)):
+    arts = [Image.new("RGBA", (100, 100), (30, 30, 30, 255)) for _ in names]
+    placed, _px = collage._placements(
+        (tuple(names), tuple(sorted(bands.items()))),
+        arts,
+        names,
+        bands,
+        [False] * len(names),
+        *size,
+        None,
+        0,
+        str,
+    )
+    return {names[p.index]: p for p in placed}
+
+
+def _from_centre(p, size: tuple[int, int]) -> float:
+    return math.hypot(p.at[0] + p.dim / 2 - size[0] / 2, p.at[1] + p.dim / 2 - size[1] / 2)
+
+
+def test_the_loudest_bird_is_drawn_biggest_and_lands_nearest_the_centre(monkeypatch):
+    monkeypatch.setattr(collage, "mass_of", lambda name: 40.0)  # mass out of the way
+    size = (1200, 900)
+    by_name = _placed([QUIET, MIDDLE, LOUD], {QUIET: 0, MIDDLE: 1, LOUD: 2}, size)
+
+    assert by_name[LOUD].dim > by_name[MIDDLE].dim > by_name[QUIET].dim
+    assert _from_centre(by_name[LOUD], size) == min(_from_centre(p, size) for p in by_name.values())
+
+
+def test_the_quiet_birds_end_up_out_at_the_edges(monkeypatch):
+    """Centrality is emergent, not assigned: the biggest goes down first on a
+    centre-out spiral and the rest fill in around it. So it is the trend that
+    holds, not a strict order - two birds of neighbouring bands can easily land
+    the same distance out once the packed cluster is recentred on the page.
+    """
+    monkeypatch.setattr(collage, "mass_of", lambda name: 40.0)
+    size = (1400, 1000)
+    names = [f"Testus sp{i:02d}" for i in range(12)]
+    bands = {name: 2 - i // 4 for i, name in enumerate(names)}  # 4 loud, 4 middling, 4 quiet
+
+    by_name = _placed(names, bands, size)
+    out = {band: [] for band in (0, 1, 2)}
+    for name, p in by_name.items():
+        out[bands[name]].append(_from_centre(p, size))
+
+    assert sum(out[2]) / 4 < sum(out[1]) / 4 < sum(out[0]) / 4
+
+
+def test_a_page_of_equal_birds_is_laid_out_as_if_the_bands_were_off(monkeypatch):
+    monkeypatch.setattr(collage, "mass_of", lambda name: 40.0)
+    names = [QUIET, MIDDLE, LOUD]
+    level = _placed(names, dict.fromkeys(names, 2))
+    off = _placed(names, {})
+    assert {n: (p.dim, p.at) for n, p in level.items()} == {
+        n: (p.dim, p.at) for n, p in off.items()
+    }
+
+
+# --- the breath -------------------------------------------------------------
+
+
+def test_the_breath_holds_a_size_change_and_nothing_else():
+    now = time.monotonic()
+    assert service._breathing(("same",), ("same",), now, 15) is True
+    assert service._breathing(("new bird",), ("same",), now, 15) is False
+    assert service._breathing(("same",), None, now, 15) is False  # nothing on the glass yet
+
+
+def test_the_breath_lets_go_once_it_is_up_and_can_be_switched_off():
+    now = time.monotonic()
+    assert service._breathing(("same",), ("same",), now - 16 * 60, 15) is False
+    assert service._breathing(("same",), ("same",), now, 0) is False
+
+
+def test_by_default_a_size_change_never_spends_a_refresh_of_its_own():
+    """The panel's rule (discussion #37): a refresh you notice should mean the
+    frame heard a new bird. So the sizes ride along with the next one."""
+    long_ago = time.monotonic() - 30 * 24 * 3600
+    assert Settings().breath_minutes == WITH_THE_BIRDS
+    assert service._breathing(("same",), ("same",), long_ago, WITH_THE_BIRDS) is True
+    assert service._breathing(("new bird",), ("same",), long_ago, WITH_THE_BIRDS) is False
+
+
+def test_sizing_by_body_mass_is_the_default():
+    assert Settings().size_by == SIZE_BY_MASS

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -13,11 +13,13 @@ from PIL import Image
 from fugleramme import fake, modes
 from fugleramme.api import ApiSource
 from fugleramme.languages import namer
+from fugleramme.names import normalize
 from fugleramme.picks import Picks
 from fugleramme.settings import Settings
 
 NOW = datetime.now().astimezone()
 BLACKBIRD, TIT = "Turdus merula", "Parus major"
+ROBIN = "Erithacus rubecula"
 
 
 def _row(id_: int, name: str, ago_hours: float) -> fake.Detection:
@@ -41,6 +43,13 @@ def images(tmp_path):
     (style / "perches").mkdir()
     Image.new("RGBA", (80, 60), (20, 20, 20, 255)).save(style / "perches" / "twig.png")
     return tmp_path
+
+
+def _draw(images, name: str) -> None:
+    """Give a species a plate, so it can hold a place on the page."""
+    Image.new("RGBA", (120, 90), (40, 40, 40, 255)).save(
+        images / "classic" / "birds" / f"{normalize(name)}.png"
+    )
 
 
 def _ctx(source, images, tmp_path, mode, **overrides):
@@ -117,6 +126,54 @@ def test_the_collage_holds_the_page_when_a_bird_already_on_it_calls_again(
 
     assert detections.species_since()[0][0] == BLACKBIRD  # the ranking did flip
     assert modes.state_key(_ctx(detections, images, tmp_path, "collage")) == before
+
+
+def test_a_limit_keeps_the_most_heard_and_the_ranking_takes_the_other_end(tmp_path, images, source):
+    detections = source(rows=[_row(3, TIT, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)])
+    for ranking, expected in (("heard", BLACKBIRD), ("rarest", TIT)):
+        ctx = _ctx(detections, images, tmp_path, "collage", species_limit=1, ranking=ranking)
+        assert modes._selected(ctx) == [expected]
+
+
+def test_a_bird_crossing_the_limit_repaints_although_the_window_never_moved(
+    tmp_path, images, detector
+):
+    """The reason the key reads the page rather than the window. Under a limit
+    two birds can trade places across it while the set of species heard sits
+    perfectly still - and the picture changes."""
+    rows = [_row(3, TIT, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)]
+    url, _httpd = detector(rows=rows)
+    detections = ApiSource(url)
+
+    def ctx():
+        return _ctx(detections, images, tmp_path, "collage", species_limit=1)
+
+    window = {name for name, _ in detections.species_since()}
+    before = modes.state_key(ctx())
+    assert modes._selected(ctx()) == [BLACKBIRD]
+
+    for id_ in range(4, 9):
+        _heard(detections, rows, _row(id_, TIT, 0))
+
+    assert {name for name, _ in detections.species_since()} == window  # same birds heard
+    assert modes._selected(ctx()) == [TIT]  # different bird on the page
+    assert modes.state_key(ctx()) != before  # so the panel is told about it
+
+
+def test_the_admin_lists_a_bird_with_no_plate_but_not_one_the_limit_left_out(
+    tmp_path, images, source
+):
+    (images / "classic" / "birds" / "parus-major.png").unlink()  # counted, cannot be drawn
+    _draw(images, ROBIN)
+    rows = [_row(4, TIT, 1), _row(3, ROBIN, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)]
+    detections = source(rows=rows)
+
+    every = modes.subjects(_ctx(detections, images, tmp_path, "collage"))
+    assert every == sorted([BLACKBIRD, ROBIN, TIT])
+
+    # One place, and the blackbird is the most heard, so the robin loses it.
+    limited = modes.subjects(_ctx(detections, images, tmp_path, "collage", species_limit=1))
+    assert limited == sorted([BLACKBIRD, TIT])  # the tit for having no plate, not for losing
 
 
 def test_the_newest_arrival_is_the_latest_first_ever(tmp_path, images, source):

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -128,6 +128,51 @@ def test_the_collage_holds_the_page_when_a_bird_already_on_it_calls_again(
     assert modes.state_key(_ctx(detections, images, tmp_path, "collage")) == before
 
 
+def test_sizing_by_how_often_heard_is_off_until_the_admin_asks(tmp_path, images, source):
+    detections = source(rows=[_row(2, TIT, 2), _row(1, BLACKBIRD, 1)])
+    by_mass = _ctx(detections, images, tmp_path, "collage")
+    by_heard = _ctx(detections, images, tmp_path, "collage", size_by="heard")
+
+    assert modes._emphasis(by_mass) == ()
+    assert modes._emphasis(by_heard)
+    # Changing the setting is the admin asking for a new page, not a drift, so
+    # both keys move and the panel redraws at once.
+    assert modes.state_key(by_mass) != modes.state_key(by_heard)
+    assert modes.steady_key(by_mass) != modes.steady_key(by_heard)
+
+
+def test_only_the_collage_bands_its_birds(tmp_path, images, source):
+    detections = source(rows=[_row(2, TIT, 2), _row(1, BLACKBIRD, 1)])
+    for mode in modes.MODES:
+        ctx = _ctx(detections, images, tmp_path, mode, size_by="heard")
+        assert bool(modes._emphasis(ctx)) is modes.mode_of(mode).windowed
+
+
+def test_a_bird_changing_band_moves_the_state_key_but_not_the_steady_one(
+    tmp_path, images, detector
+):
+    """The one difference between the two keys, and so the only change the
+    render loop may sit on. A new species moves both and goes straight through.
+    """
+    rows = [_row(i, BLACKBIRD, 1) for i in range(1, 40)] + [_row(40, TIT, 1)]
+    url, _httpd = detector(rows=rows)
+    detections = ApiSource(url)
+
+    def ctx():
+        return _ctx(detections, images, tmp_path, "collage", size_by="heard")
+
+    state, steady = modes.state_key(ctx()), modes.steady_key(ctx())
+    for id_ in (41, 42):
+        _heard(detections, rows, _row(id_, TIT, 0))
+
+    assert modes.state_key(ctx()) != state  # the tit grew
+    assert modes.steady_key(ctx()) == steady  # but it is the same page of birds
+
+    _draw(images, ROBIN)
+    _heard(detections, rows, _row(43, ROBIN, 0))
+    assert modes.steady_key(ctx()) != steady  # a newcomer never waits
+
+
 def test_a_limit_keeps_the_most_heard_and_the_ranking_takes_the_other_end(tmp_path, images, source):
     detections = source(rows=[_row(3, TIT, 1), _row(2, BLACKBIRD, 1), _row(1, BLACKBIRD, 2)])
     for ranking, expected in (("heard", BLACKBIRD), ("rarest", TIT)):
@@ -149,7 +194,7 @@ def test_a_bird_crossing_the_limit_repaints_although_the_window_never_moved(
         return _ctx(detections, images, tmp_path, "collage", species_limit=1)
 
     window = {name for name, _ in detections.species_since()}
-    before = modes.state_key(ctx())
+    steady = modes.steady_key(ctx())
     assert modes._selected(ctx()) == [BLACKBIRD]
 
     for id_ in range(4, 9):
@@ -157,7 +202,7 @@ def test_a_bird_crossing_the_limit_repaints_although_the_window_never_moved(
 
     assert {name for name, _ in detections.species_since()} == window  # same birds heard
     assert modes._selected(ctx()) == [TIT]  # different bird on the page
-    assert modes.state_key(ctx()) != before  # so the panel is told about it
+    assert modes.steady_key(ctx()) != steady  # so the panel is told about it
 
 
 def test_the_admin_lists_a_bird_with_no_plate_but_not_one_the_limit_left_out(

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,104 @@
+"""Which birds make the page (#53).
+
+A busy station hears more species than one sheet can hold. The admin's limit and
+ranking decide which ones it keeps, and the frame's own ceiling - MAX_BIRDS, a
+render budget - spends itself on the most heard rather than the first by name.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from fugleramme.names import normalize
+from fugleramme.picks import Picks
+from fugleramme.render import collage
+from fugleramme.render.collage import RANK_RAREST
+
+
+class _Counted:
+    """Just enough of a Source for gather_entries: who was heard, how often."""
+
+    def __init__(self, counts: dict[str, int]):
+        self._counts = counts
+
+    def species_since(self, hours: int = 24) -> list[tuple[str, int]]:
+        return sorted(self._counts.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def _garden(tmp_path, count: int, drawn: int | None = None) -> list[str]:
+    """`count` species, the i-th heard i+1 times, so the busiest sort last by
+    name. Only the first `drawn` of them get a plate."""
+    birds = tmp_path / "classic" / "birds"
+    birds.mkdir(parents=True, exist_ok=True)
+    names = [f"Testus sp{i:02d}" for i in range(count)]
+    for name in names[: count if drawn is None else drawn]:
+        Image.new("RGBA", (20, 16), (30, 30, 30, 255)).save(birds / f"{normalize(name)}.png")
+    return names
+
+
+def _on_page(tmp_path, names: list[str], **kwargs) -> list[str]:
+    source = _Counted({name: i + 1 for i, name in enumerate(names)})
+    return collage.selected_species(source, tmp_path, "classic", **kwargs)
+
+
+def test_the_frames_own_ceiling_keeps_the_most_heard_not_the_first_by_name(tmp_path):
+    """MAX_BIRDS is a render budget, so which birds it spends on is a real
+    choice. Cutting by name instead retired the busiest bird in the garden for
+    being called Turdus rather than Anas."""
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    kept = _on_page(tmp_path, names)
+
+    assert set(kept) == set(names[-collage.MAX_BIRDS :])  # the busiest, not the first
+    assert kept == sorted(kept)  # and still handed over in name order
+
+
+def test_a_limit_keeps_the_most_heard_by_default(tmp_path):
+    names = _garden(tmp_path, 20)
+    assert _on_page(tmp_path, names, limit=5) == sorted(names[-5:])
+
+
+def test_the_rarest_ranking_keeps_the_other_end(tmp_path):
+    """What the request was for: the residents are the same every day, so the
+    visitor worth seeing is the one at the bottom of the list."""
+    names = _garden(tmp_path, 20)
+    assert _on_page(tmp_path, names, limit=5, ranking=RANK_RAREST) == sorted(names[:5])
+
+
+def test_no_limit_is_the_default_and_still_answers_to_the_frames_ceiling(tmp_path):
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    assert len(_on_page(tmp_path, names)) == collage.MAX_BIRDS
+    assert len(_on_page(tmp_path, names, limit=collage.NO_LIMIT)) == collage.MAX_BIRDS
+    assert len(_on_page(tmp_path, names, limit=10)) == 10
+
+
+def test_the_ranking_has_no_say_until_there_is_a_limit(tmp_path):
+    """The admin greys the ranking out under "No limit", so a saved "rarest"
+    must not quietly decide which forty a busy station gets."""
+    names = _garden(tmp_path, collage.MAX_BIRDS + 5)
+    by_default = _on_page(tmp_path, names)
+    assert _on_page(tmp_path, names, ranking=RANK_RAREST) == by_default
+    assert set(by_default) == set(names[-collage.MAX_BIRDS :])
+
+
+def test_a_species_with_no_artwork_never_takes_a_place_from_one_that_has_it(tmp_path):
+    # The loudest bird in the garden, and the style cannot draw it. Dropping it
+    # after the limit rather than before would spend a place on nothing.
+    names = _garden(tmp_path, 12, drawn=11)
+    loudest = names[-1]
+
+    kept = _on_page(tmp_path, names, limit=5)
+
+    assert loudest not in kept
+    assert kept == sorted(names[6:11])  # the five busiest it can actually draw
+
+
+def test_the_entries_carry_the_artwork_each_selected_bird_is_wearing(tmp_path):
+    names = _garden(tmp_path, 6)
+    source = _Counted({name: i + 1 for i, name in enumerate(names)})
+
+    entries = collage.gather_entries(
+        source, tmp_path, "classic", Picks(tmp_path / "artwork.json"), limit=3
+    )
+
+    assert [name for name, _path in entries] == sorted(names[-3:])
+    assert all(path is not None for _name, path in entries)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,19 +4,35 @@ BirdNET-Go restarts is worse than one that is a few minutes stale."""
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 from PIL import Image
 
-from fugleramme import api, modes, service
+from fugleramme import api, fake, modes, service
 from fugleramme.config import Config
-from fugleramme.settings import Settings, SettingsStore
+from fugleramme.panel import Panel
+from fugleramme.settings import WITH_THE_BIRDS, Settings, SettingsStore
+
+BLACKBIRD, TIT = "Turdus merula", "Parus major"
 
 
 class _Stop(Exception):
     """Breaks the otherwise endless loop from inside its own sleep."""
+
+
+class _Glass:
+    """An Inky that costs nothing to refresh, so the loop takes the panel path."""
+
+    resolution = (1600, 1200)
+
+    def set_image(self, image):
+        pass
+
+    def show(self):
+        pass
 
 
 @pytest.fixture
@@ -65,6 +81,56 @@ def test_the_loop_holds_its_last_page_when_the_detector_goes_away(
     assert render.call_count == 1  # and did not draw an empty page over it
     assert len(set(ticks)) == 1  # and the file they would have written it to is untouched
     assert np.asarray(Image.open(config.output_path)).std() > 1  # birds, not bare paper
+
+
+@pytest.mark.parametrize(("panelled", "renders"), [(False, 2), (True, 1)])
+def test_only_a_frame_with_a_panel_holds_its_breath(
+    tmp_path, images, detector, monkeypatch, panelled, renders
+):
+    """The breath is buying a 20-30s e-ink refresh. A web-only frame has none to
+    buy, so a size change reaches it as directly as it did before the setting -
+    holding a browser page back would cost the reader and save nobody."""
+    now = datetime.now().astimezone()
+    rows = [fake.Detection(40, now - timedelta(hours=1), TIT, 0.9, False)]
+    rows += [
+        fake.Detection(i, now - timedelta(hours=1), BLACKBIRD, 0.9, False) for i in range(1, 40)
+    ]
+    url, _httpd = detector(rows=rows)
+    monkeypatch.setattr(api, "_TTL", 0)  # the loop must see the new detections
+    SettingsStore(tmp_path / "settings.json", Settings()).update(
+        detector_url=url, size_by="heard", breath_minutes=WITH_THE_BIRDS
+    )
+    config = Config(
+        images_dir=images,
+        detector_url=url,
+        output_path=tmp_path / "frame.png",
+        host="127.0.0.1",
+        port=0,
+        config_path=tmp_path / "settings.json",
+    )
+    ticks: list[int] = []
+
+    def sleep(_seconds):
+        ticks.append(1)
+        if len(ticks) == 1:
+            # Enough to lift the tit a band, and not a single new species: the
+            # steady key does not move, so only the breath decides.
+            for id_ in (41, 42):
+                rows.insert(0, fake.Detection(id_, now, TIT, 0.9, False))
+        if len(ticks) == 3:
+            raise _Stop
+
+    with (
+        patch.object(service, "init_panel", return_value=Panel(_Glass()) if panelled else None),
+        patch.object(service.buttons, "watch"),
+        patch.object(service.updates, "available", return_value=None),
+        patch.object(service.modes, "render", side_effect=modes.render) as render,
+        patch.object(service.time, "sleep", sleep),
+        pytest.raises(_Stop),
+    ):
+        service.run(config)
+
+    assert render.call_count == renders
 
 
 def test_the_configured_detector_is_rebuilt_only_when_the_settings_name_another(tmp_path, detector):


### PR DESCRIPTION
## What this changes

The other half of the comment on #53, stacked on #57: it includes that PR's commit until it's merged, and I'll rebase it then. This one goes beyond the issue, so it's the one to push back on if it doesn't match where you want the collage to go.

- **Bird size**: a new setting, "Real body size" by default, with "Body size, and how often heard" as the alternative. The birds you hear most get drawn bigger and go nearer the middle, since size and centrality are already one number in the packer. Body mass still counts, and the two are tuned to about the same strength so a swan doesn't shrink away just for being quiet.
- Counts reach the layout as three broad bands relative to the busiest species, never as raw counts, so one more detection never repacks the page. A band is measured against the birds on the page rather than the window, otherwise the ten rarest would all come out the same size next to a resident crow.
- **Redraw the panel for a size change**: a wait for the e-ink panel. A new bird, a setting or a button press always refreshes the panel right away. A change in sizes alone doesn't. By default it waits until a new bird arrives, or you can pick a number of minutes instead. I took this from your comment in #37 that a refresh should mean a new bird. Frames without a panel don't wait at all, so the web view is not affected.


I run it web-only, so the breath is covered by tests but I haven't seen it in real life.

## Checks

- [x] `uv run ruff format && uv run ruff check && uv run mypy && uv run pytest -q`
- [x] `uv.lock` committed, if `pyproject.toml` changed